### PR TITLE
Simplify build and separate config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,79 +1,26 @@
-FROM ubuntu:16.04
+FROM tensorflow/tensorflow:1.8.0-py3
 LABEL maintainer="Rub21"
 ENV workdir /usr/src/app
 RUN mkdir $workdir
-RUN apt-get update && apt-get -y upgrade
+RUN apt-get update -y
 RUN apt-get install -y \
-    build-essential \
-    libreadline-gplv2-dev \
-    libncursesw5-dev \
-    software-properties-common \
-    python-software-properties \
     libsqlite3-dev \
-    tk-dev \
-    libgdbm-dev \
-    libc6-dev \
-    libbz2-dev \
-    zlib1g-dev \
-    libssl-dev \
     libcurl4-openssl-dev \
+    libssl-dev \
     wget \
-    unzip \
     git
-# Install Python 3.6
-RUN wget https://www.python.org/ftp/python/3.6.0/Python-3.6.0.tar.xz && \
-    tar xvf Python-3.6.0.tar.xz && \
-    cd Python-3.6.0/ && \
-    ./configure && \
-    make install
-RUN ln -s -f /usr/local/bin/python3 /usr/bin/python
-RUN ln -s -f /usr/local/bin/pip3 /usr/bin/pip
-RUN pip install --upgrade pip && \
-    pip install -U pip && \
-    pip install -U setuptools
 # Install tippecanoe
 RUN git clone --progress https://github.com/mapbox/tippecanoe.git && \
     cd tippecanoe && \
-    git checkout af69c85d2399919db0872e73549d8294868754ea && \
-    make && \
+    make -j && \
     make install
-# Install label-maker + dependencies
+# Install label-maker
 RUN pip install \
-    Cerberus==1.1 \
-    click==6.7 \
-    geojson==2.3.0 \
-    homura==0.1.5 \
-    humanize==0.5.1 \
-    mapbox-vector-tile==1.2.0 \
-    mbutil==0.3.0 \
-    mercantile==1.0.0 \
-    numpy==1.13.3 \
-    olefile==0.44 \
-    Pillow==4.3.0 \
-    protobuf==3.5.0.post1 \
-    pyclipper==1.0.6 \
-    pycurl==7.43.0.1 \
-    pyproj==1.9.5.1 \
-    rasterio==1.0a12 \
-    requests==2.11.0 \
-    Shapely==1.6.3 \
-    six==1.10.0 \
-    tilepie==0.2.1 \
-    label-maker==0.3.1
-# Install tensorFlow + dependencies
-RUN apt-get install -y \
-    protobuf-compiler \
-    python-pil \
-    python-lxml \
-    python-tk
+    label-maker==0.3.1 --ignore-installed pycurl
+# Install remaining dependencies
 RUN pip install \
-    bleach==1.5.0 \
     Cython==0.28.2 \
-    lxml==4.2.1 \
-    jupyter==1.0.0 \
-    matplotlib==2.2.2 \
-    pandas==0.22.0 \
-    tensorflow==1.8.0
+    lxml==4.2.1
 # Install Proto
 RUN wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip -P $workdir
 RUN unzip $workdir/protoc-3.2.0-linux-x86_64.zip -d $workdir/protoc3

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,24 +9,29 @@ RUN apt-get install -y \
     libssl-dev \
     wget \
     git
+
 # Install tippecanoe
 RUN git clone --progress https://github.com/mapbox/tippecanoe.git && \
     cd tippecanoe && \
     make -j && \
     make install
+
 # Install label-maker
 RUN pip install \
     label-maker==0.3.1 --ignore-installed pycurl
-# Install remaining dependencies
+
+# Install remaining python dependencies
 RUN pip install \
     Cython==0.28.2 \
     lxml==4.2.1
+
 # Install Proto
 RUN wget https://github.com/google/protobuf/releases/download/v3.2.0/protoc-3.2.0-linux-x86_64.zip -P $workdir
 RUN unzip $workdir/protoc-3.2.0-linux-x86_64.zip -d $workdir/protoc3
 RUN mv -f $workdir/protoc3/bin/* /usr/local/bin/
 RUN mv -f $workdir/protoc3/include/* /usr/local/include/
 RUN ln -s -f /usr/local/bin/protoc /usr/bin/protoc
+
 # Setup TensorFlow Object Detection API
 RUN git clone --progress https://github.com/tensorflow/models.git $workdir/models && \
     cd $workdir/models && \
@@ -37,10 +42,10 @@ RUN cd $workdir/models/research && \
 ENV PYTHONPATH=$PYTHONPATH:/usr/src/app/models/research:/usr/src/app/models/research/slim
 RUN cd $workdir/models/research && \
     python object_detection/builders/model_builder_test.py
+
 # Create TFRecords for model training
 RUN git clone --progress https://github.com/developmentseed/label-maker.git $workdir/label-maker && \
     cd $workdir/label-maker && \
     git checkout 94f1863945c47e1b69fe0d6d575caa0b42aa8d63
-COPY ./config.json $workdir
 COPY ./script.sh $workdir
 CMD ["bash", "script.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,12 @@ ENV PYTHONPATH=$PYTHONPATH:/usr/src/app/models/research:/usr/src/app/models/rese
 RUN cd $workdir/models/research && \
     python object_detection/builders/model_builder_test.py
 
+# Object detection model setup
+# https://github.com/developmentseed/label-maker/blob/master/examples/walkthrough-tensorflow-object-detection.md#object-detection-model-setup
+RUN cd $WORKDIR && wget http://download.tensorflow.org/models/object_detection/ssd_inception_v2_coco_2017_11_17.tar.gz && \
+    tar xvf ssd_inception_v2_coco_2017_11_17.tar.gz && \
+    mv ssd_inception_v2_coco_2017_11_17 $TOD/
+
 # Create TFRecords for model training
 RUN git clone --progress https://github.com/developmentseed/label-maker.git $workdir/label-maker && \
     cd $workdir/label-maker && \

--- a/README.md
+++ b/README.md
@@ -1,18 +1,20 @@
 # Tensorflow building detection
 
-This is a docker container runs all steps mentioned in: [Example Use: A building detector with TensorFlow API](https://github.com/developmentseed/label-maker/blob/master/examples/walkthrough-tensorflow-object-detection.md)
+This is a docker image for running all the steps mentioned in: [Example Use: A building detector with TensorFlow API](https://github.com/developmentseed/label-maker/blob/master/examples/walkthrough-tensorflow-object-detection.md)
 
 ### Usage
 
+First add your Mapbox Access Token to `config.example.json` and rename it to `config.json`. You can also update the country, bounding box, or zoom level if you'd like to try building detection in another area.
+
 ```
 docker build -t tbd .
-docker run -it tbd
+docker run -v $PWD/config.json:/usr/src/app/config.json tbd
 ```
 
 **Manually**
 
 ```
-docker run -it tbd /bin/bash
+docker run -it --rm -v $PWD/config.json:/usr/src/app/config.json tbd /bin/bash
 ./script.sh
 ```
 
@@ -30,7 +32,3 @@ INFO:tensorflow:global step 3: loss = 289.7815 (21.244 sec/step)
 ...
 
 ```
-
-
-
-	

--- a/config.example.json
+++ b/config.example.json
@@ -6,7 +6,7 @@
 		"name": "Buildings",
 		"filter": ["has", "building"]
 	}],
-	"imagery": "http://a.tiles.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.jpg?access_token=pk.eyJ1Ijoib3BlbnN0cmVldG1hcCIsImEiOiJhNVlHd29ZIn0.ti6wATGDWOmCnCYen-Ip7Q",
+	"imagery": "http://a.tiles.mapbox.com/v4/mapbox.satellite/{z}/{x}/{y}.jpg?access_token=ACCESS_TOKEN",
 	"background_ratio": 1,
 	"ml_type": "object-detection"
 }

--- a/script.sh
+++ b/script.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 label-maker download
 label-maker labels
-#Preview : https://github.com/developmentseed/label-maker/issues/79
-#label-maker preview -n 10
 label-maker images
 
 WORKDIR='/usr/src/app'

--- a/script.sh
+++ b/script.sh
@@ -15,11 +15,6 @@ python tf_records_generation.py --label_input=labels.npz \
         --train_rd_path=data/train_buildings.record \
         --test_rd_path=data/test_buildings.record
 
-# Object detection model setup
-# https://github.com/developmentseed/label-maker/blob/master/examples/walkthrough-tensorflow-object-detection.md#object-detection-model-setup
-cd $WORKDIR && wget http://download.tensorflow.org/models/object_detection/ssd_inception_v2_coco_2017_11_17.tar.gz
-tar xvf ssd_inception_v2_coco_2017_11_17.tar.gz
-mv ssd_inception_v2_coco_2017_11_17 $TOD/
 mkdir $TOD/training
 cp label-maker/examples/utils/ssd_inception_v2_coco.config $TOD/training
 cp label-maker/examples/utils/building_od.pbtxt $TOD/data


### PR DESCRIPTION
@Rub21 let me know if the new README and changes I made make sense:
- Built the image from the base tensorflow + python3 image and removed relevant installs
- Added the model download to the image build
- Removed the config file (and tokens) from the build and repo. These can be mounted at runtime so that users can adjust as needed (and add their own credentials)

I haven't tested the `run` because I'm on airport WiFi but the build worked 